### PR TITLE
feat: add %crate_install_bin

### DIFF
--- a/macros.anda
+++ b/macros.anda
@@ -23,3 +23,10 @@
   rpm.define("buildsubdir " .. ((url:gsub("/(%.git)?$", "")):gsub("^.+/", "")))
   print(command .. " && cd " .. ((url:gsub("/(%.git)?$", "")):gsub("^.+/", "")))
 }
+
+# applicable to specs generated using rust2rpm
+# where installing crate source as library is unnecessary, use this macro
+# to install crates that build as single binary
+%crate_install_bin (\
+%{__install} -m 0755 target/rpm/%{?crate} -D %{buildroot}%{_bindir}/%{?crate} \
+)


### PR DESCRIPTION
when i became aware of %cargo_build and %cargo_install used together being redundant in 9/10 cases i wanted to find a better solution for automating expected and reproducible tasks during building rust packages

i'm not saying this macro will satisfy usecases all of the time, but compared with invocations of `install` in building packages written in other languages, rust crates that are not libs and do build as a single binary will 99% use the binary name %{crate}

it's not particularly complex, but idk it would save me like 1.5 seconds each time?

let me know what you think mado:)