### PR TITLE
feat: Zig macros

### DIFF
--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -9,22 +9,22 @@
 %zig_build_march(v2v3v4:) %{lua:
 if rpm.isdefined("-v2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu" .. "x86_64_v2")
+    rpm.define("_zig_cpu " .. "x86_64_v2")
     else error("Incompatible architecture for march option.") 
     end
    elseif rpm.isdefined("-v3") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu" .. "x86_64_v3")
+    rpm.define("_zig_cpu " .. "x86_64_v3")
     else error("Incompatible architecture for march option.") 
     end
   elseif rpm.isdefined("-v4") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu" .. "x86_64_v4")
+    rpm.define("_zig_cpu " .. "x86_64_v4")
     else error("Incompatible architecture for march option.") 
     end
   else
    local target = rpm.expand("%_target_cpu")
-   rpm.define("_zig_cpu" .. target)
+   rpm.define("_zig_cpu " .. target)
   end} \
 %{shrink: \
     %zig \
@@ -52,17 +52,17 @@ if rpm.isdefined("-v2") then
     end
    elseif rpm.isdefined("-v3") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu" .. "x86_64_v3")
+    rpm.define("_zig_cpu " .. "x86_64_v3")
     else error("Incompatible architecture for march option.") 
     end
   elseif rpm.isdefined("-v4") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu" .. "x86_64_v4")
+    rpm.define("_zig_cpu " .. "x86_64_v4")
     else error("Incompatible architecture for march option.") 
     end
   elseif rpm.isdefined("-t") then
     local target = rpm.expand("%_target_cpu")
-    rpm.define("_zig_cpu" .. target)
+    rpm.define("_zig_cpu " .. target)
     end
    end} \
 %{shrink: \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -2,6 +2,9 @@
 # Generally --release=fast should be used with these
 # But some packages it may still be desirable to emit extra debug info
 # Note that Zig also supports Zen microarchitectures, however RPM does not
+# -v2: Build optimized for x86_64_v2
+# -v3: Build optimized for x86_64_v3
+# -v4: Build optimized for x86_64_v4
 %zig_build_march(v2v3v4:) %{lua:
 if rpm.isdefined("-v2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
@@ -33,7 +36,12 @@ end} \
 # It however strips some debug info
 # This is best used in projects that have flags to override the debug stripping in fast release mode
 # Example for the above: Ghostty
-%zig_build_fast(v2v3v4:) \ 
+# Option reference:
+# -v2: Build release fast optimized for x86_64_v2
+# -v3: Build release fast optimized for x86_64_v3
+# -v4: Build release fast optimized for x86_64_v4
+# -t:  "Target." Build release fast optimized for _target_arch (fallback option, mainly for ARM architectures)
+%zig_build_fast(v2v3v4t:) \ 
  %global _zig_release_mode fast \
  %{lua:
  -- Only succeed with flags on x86_64 architectures.
@@ -51,6 +59,10 @@ end} \
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu" .. "x86_64_v4")
     else error("Incompatible architecture for march option.") 
+    end
+  elseif rpm.isdefined("-t") then
+    local target = rpm.expand("%_target_cpu")
+    rpm.define("_zig_cpu" .. target)
     end
    end} \
 %{shrink: \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -2,26 +2,11 @@
 # Generally --release=fast should be used with these
 # But some packages it may still be desirable to emit extra debug info
 # Note that Zig also supports Zen microarchitectures, however RPM does not
-# -2: Build optimized for x86_64_v2
-# -3: Build optimized for x86_64_v3
-# -4: Build optimized for x86_64_v4
+# -a: Choose a specific (micro)architecture to build for
 # No flag: Fallback to _target_arch
-%zig_build_march(234) %{lua:
-if rpm.isdefined("-2") then
-    if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu " .. "x86_64_v2")
-    else error("Incompatible architecture for march option.") 
-    end
-   elseif rpm.isdefined("-3") then
-    if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu " .. "x86_64_v3")
-    else error("Incompatible architecture for march option.") 
-    end
-  elseif rpm.isdefined("-4") then
-    if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu " .. "x86_64_v4")
-    else error("Incompatible architecture for march option.") 
-    end
+%zig_build_march(a:) %{lua:
+if rpm.isdefined("-a") then
+  rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
   else
    local target = rpm.expand("%_target_cpu")
    rpm.define("_zig_cpu " .. target)
@@ -37,27 +22,11 @@ if rpm.isdefined("-2") then
 # This is best used in projects that have flags to override the debug stripping in fast release mode
 # Example for the above: Ghostty
 # Option reference:
-# -2: Build release fast optimized for x86_64_v2
-# -3: Build release fast optimized for x86_64_v3
-# -4: Build release fast optimized for x86_64_v4
-# -t:  "Target." Build release fast optimized for _target_arch (fallback option, mainly for ARM architectures)
-%zig_build_fast(234t) %{lua:
- -- Only succeed with flags on x86_64 architectures.
-   if rpm.isdefined("-2") then
-    if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu " .. "x86_64_v2")
-    else error("Incompatible architecture for march option.") 
-    end
-   elseif rpm.isdefined("-3") then
-    if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu " .. "x86_64_v3")
-    else error("Incompatible architecture for march option.") 
-    end
-  elseif rpm.isdefined("-4") then
-    if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu " .. "x86_64_v4")
-    else error("Incompatible architecture for march option.") 
-    end
+# -a: "Arch." Choose a specific (micro)architecture to build for
+# -t: "Target." Build release fast optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
+%zig_build_fast(ta:) %{lua:
+   if rpm.isdefined("-a") then
+    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
   elseif rpm.isdefined("-t") then
     local target = rpm.expand("%_target_cpu")
     rpm.define("_zig_cpu " .. target)

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -21,7 +21,7 @@
 # -r: "Release." Choose the build/release mode Zig will use. Note that "safe" is the default set by the Zig macros so it is never necessary to specify this option.
 %zig_build_target(cr:) %{lua:
    if opt.c then
-    if rpm.expand("%1"):find("%w") then
+    if rpm.expand("%?1"):find("%w") then
      rpm.define("_zig_cpu " .. rpm.expand("%1"))
     else
      rpm.define("_zig_cpu " .. rpm.expand("%{_target_cpu}"))

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -6,18 +6,18 @@
 # -v3: Build optimized for x86_64_v3
 # -v4: Build optimized for x86_64_v4
 # No flag: Fallback to _target_arch
-%zig_build_march(v2v3v4:) %{lua:
-if rpm.isdefined("-v2") then
+%zig_build_march(234:) %{lua:
+if rpm.isdefined("-2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu " .. "x86_64_v2")
     else error("Incompatible architecture for march option.") 
     end
-   elseif rpm.isdefined("-v3") then
+   elseif rpm.isdefined("-3") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu " .. "x86_64_v3")
     else error("Incompatible architecture for march option.") 
     end
-  elseif rpm.isdefined("-v4") then
+  elseif rpm.isdefined("-4") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu " .. "x86_64_v4")
     else error("Incompatible architecture for march option.") 
@@ -41,21 +41,21 @@ if rpm.isdefined("-v2") then
 # -v3: Build release fast optimized for x86_64_v3
 # -v4: Build release fast optimized for x86_64_v4
 # -t:  "Target." Build release fast optimized for _target_arch (fallback option, mainly for ARM architectures)
-%zig_build_fast(v2v3v4t:) \ 
+%zig_build_fast(234t:) \ 
  %global _zig_release_mode fast \
  %{lua:
  -- Only succeed with flags on x86_64 architectures.
-   if rpm.isdefined("-v2") then
+   if rpm.isdefined("-2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu" .. "x86_64_v2")
     else error("Incompatible architecture for march option.") 
     end
-   elseif rpm.isdefined("-v3") then
+   elseif rpm.isdefined("-3") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu " .. "x86_64_v3")
     else error("Incompatible architecture for march option.") 
     end
-  elseif rpm.isdefined("-v4") then
+  elseif rpm.isdefined("-4") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu " .. "x86_64_v4")
     else error("Incompatible architecture for march option.") 

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -1,0 +1,49 @@
+# --release=fast is the recommended way to build most projects that rely on performance optimizations
+# It however strips some debug info
+# This is best used in projects that have flags to override the debug stripping in fast release mode
+# Example for the above: Ghostty
+%zig_build_fast \
+ %global _zig_release_mode fast \
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}
+
+# Zig microarch support
+# Generally --release=fast should be used with these
+# But I have made it so by default additional debug info should still be emitted
+# Note that Zig also supports Zen microarchitectures, however RPM does not
+%zig_build_v3 \
+ %global _zig_cpu x86_64_v3 \
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}
+
+%zig_build_v3_fast \
+ %global _zig_release_mode fast \
+ %global _zig_cpu x86_64_v3 \
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}
+
+%zig_build_v4 \
+ %global _zig_cpu x86_64_v4 \
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}
+
+%zig_build_v4_fast \
+ %global _zig_release_mode fast \
+ %global _zig_cpu x86_64_v4 \
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -1,52 +1,37 @@
-# Zig microarch support
-# Generally --release=fast should be used with these
-# But some packages it may still be desirable to emit extra debug info
-# Note that Zig also supports Zen microarchitectures, however RPM does not
-# -a: Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
-# No flag: Fallback to _target_arch
-%zig_build_march(a:) %{lua:
-   rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}%{?!-a:%_target_cpu}"))} \
-%{shrink: \
-    %zig \
-        build \
-        %{?_zig_build_options} \
-}
+## Note: Zig microarch support
+# Generally ReleaseFast should be used with microarch builds for optimization.
+# But some packages it may still be desirable to emit extra debug info.
+# Note that Zig also supports Zen microarchitectures, however RPM does not.
+# Reference: https://ziglang.org/documentation/master/#Targets
 
-# --release=fast is the recommended way to build most projects that rely on performance optimizations
-# It however strips some debug info
-# This is best used in projects that have flags to override the debug stripping in fast release mode
+## Note:
+# ReleaseFast is the recommended way to build most projects that rely on performance optimizations.
+# It however strips some debug info.
+# This is best used in projects that have flags to override the debug stripping in fast release mode.
 # Example for the above: Ghostty
-# Option reference:
-# -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
-# -t: "Target." Build release fast optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
-%zig_build_fast(ta:) %{lua:
-   if rpm.isdefined("-a") then
-    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
-   elseif rpm.isdefined("-t") then
-    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
+# ReleaseSmall is the recommended way to build some projects, as it builds smaller bins and in some programs has comparable performance.
+# It however strips some debug info, like ReleaseFast.
+# There is also ReleaseDebug, but this is almost never a good idea for distributed programs as the build size is large and performance is poor.
+# Reference: https://ziglang.org/documentation/master/#Build-Mode
+
+
+## Option reference:
+# -c (with argument): "CPU." Choose a specific CPU (micro)architecture to build for. Can also be used to enable/disable CPU features (example: AVX2)
+# -c (without argument): Fallback to the target architecture set by RPM (generic option, only applicable to arches where RPM and Zig use the same format)
+# -r: "Release." Choose the build/release mode Zig will use. Note that "safe" is the default set by the Zig macros so it is never necessary to specify this option.
+%zig_build_target(cr:) %{lua:
+   if opt.c then
+    if rpm.expand("%1"):find("%w") then
+     rpm.define("_zig_cpu " .. rpm.expand("%1"))
+    else
+     rpm.define("_zig_cpu " .. rpm.expand("%{_target_cpu}"))
+    end
+   end
+   if opt.r then
+    rpm.define("_zig_release_mode " .. rpm.expand("%{?-r:%{-r*}}"))
    end} \
-%global _zig_release_mode fast \
 %{shrink: \
     %zig \
         build \
         %{?_zig_build_options} \
 }
-
-# --release=small is the recommended way to build some projects, as it builds smaller bins and in some programs has comparable performance
-# It however strips some debug info, like --release=fast
-# Option reference:
-# -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
-# -t: "Target." Build release small optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
-%zig_build_small(ta:) %{lua:
-   if rpm.isdefined("-a") then
-    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
-   elseif rpm.isdefined("-t") then
-    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
-   end} \
-%global _zig_release_mode small \
-%{shrink: \
-    %zig \
-        build \
-        %{?_zig_build_options} \
-}
-

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -4,7 +4,9 @@
 # Example for the above: Ghostty
 %zig_build_fast \
  %global _zig_release_mode fast \
-%ifarch x86_64_v3
+%ifarch x86_64_v2
+ %global _zig_cpu x86_64_v2 \
+%elifarch x86_64_v3
  %global _zig_cpu x86_64_v3 \
 %elifarch x86_64_v4
  %global _zig_cpu x86_64_v4 \
@@ -20,6 +22,8 @@
 # But some packages it may still be desirable to emit extra debug info
 # Note that Zig also supports Zen microarchitectures, however RPM does not
 %zig_build_march \
+%ifarch x86_64_v2
+ %global _zig_cpu x86_64_v2 \
 %ifarch x86_64_v3
  %global _zig_cpu x86_64_v3 \
 %elifarch x86_64_v4

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -2,7 +2,7 @@
 # Generally --release=fast should be used with these
 # But some packages it may still be desirable to emit extra debug info
 # Note that Zig also supports Zen microarchitectures, however RPM does not
-# -a: Choose a specific (micro)architecture to build for
+# -a: Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
 # No flag: Fallback to _target_arch
 %zig_build_march(a:) %{lua:
 if rpm.isdefined("-a") then
@@ -22,7 +22,7 @@ if rpm.isdefined("-a") then
 # This is best used in projects that have flags to override the debug stripping in fast release mode
 # Example for the above: Ghostty
 # Option reference:
-# -a: "Arch." Choose a specific (micro)architecture to build for
+# -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
 # -t: "Target." Build release fast optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
 %zig_build_fast(ta:) %{lua:
    if rpm.isdefined("-a") then

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -35,3 +35,22 @@ if rpm.isdefined("-a") then
         build \
         %{?_zig_build_options} \
 }
+
+# --release=small is the recommended way to build some projects, as it builds smaller bins and in some programs has comparable performance
+# It however strips some debug info, like --release=fast
+# Option reference:
+# -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
+# -t: "Target." Build release fast optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
+%zig_build_small(ta:) %{lua:
+   if rpm.isdefined("-a") then
+    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
+  elseif rpm.isdefined("-t") then
+    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
+  end} \
+%global _zig_release_mode small \
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}
+

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -40,7 +40,7 @@ if rpm.isdefined("-a") then
 # It however strips some debug info, like --release=fast
 # Option reference:
 # -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
-# -t: "Target." Build release fast optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
+# -t: "Target." Build release small optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
 %zig_build_small(ta:) %{lua:
    if rpm.isdefined("-a") then
     rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -5,11 +5,7 @@
 # -a: Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
 # No flag: Fallback to _target_arch
 %zig_build_march(a:) %{lua:
-   if rpm.isdefined("-a") then
-    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
-   else
-    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
-   end} \
+   rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}%{?!-a:%_target_cpu}"))} \
 %{shrink: \
     %zig \
         build \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -18,7 +18,7 @@ if rpm.isdefined("-v2") then
     rpm.define("_zig_cpu" .. "x86_64_v4")
     else error("Incompatible architecture for march option.") 
     end
-  elseif rpm.expand("%_target_cpu"):find("^x86_64_v%d$") then
+  else
    local target = rpm.expand("%_target_cpu")
    rpm.define("_zig_cpu" .. target)
    end

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -5,6 +5,7 @@
 # -v2: Build optimized for x86_64_v2
 # -v3: Build optimized for x86_64_v3
 # -v4: Build optimized for x86_64_v4
+# No flag: Fallback to _target_arch
 %zig_build_march(v2v3v4:) %{lua:
 if rpm.isdefined("-v2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -22,13 +22,8 @@
 # But some packages it may still be desirable to emit extra debug info
 # Note that Zig also supports Zen microarchitectures, however RPM does not
 %zig_build_march \
-%ifarch x86_64_v2
- %global _zig_cpu x86_64_v2 \
-%elifarch x86_64_v3
- %global _zig_cpu x86_64_v3 \
-%elifarch x86_64_v4
- %global _zig_cpu x86_64_v4 \
-%endif
+%{expr:0%{lua:if rpm.expand("%_target_cpu"):find("^x86_64_v%d$") then print("1") else error("Unsupported architecture.") end} ? "%_target_cpu" : ""} \
+ %global _zig_cpu %{_target_cpu} \
 %{shrink: \
     %zig \
         build \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -17,13 +17,11 @@
 # This is best used in projects that have flags to override the debug stripping in fast release mode
 # Example for the above: Ghostty
 # Option reference:
-# -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
-# -t: "Target." Build release fast optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
-%zig_build_fast(ta:) %{lua:
+# -a (with option): "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
+# -a (without option): Build release fast optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
+%zig_build_fast(a::) %{lua:
    if rpm.isdefined("-a") then
-    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
-   elseif rpm.isdefined("-t") then
-    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
+    rpm.define("_zig_cpu " .. rpm.expand("%{?-a*:%{-a*}}%{?!-a*:%_target_cpu}"))
    end} \
 %global _zig_release_mode fast \
 %{shrink: \
@@ -36,12 +34,10 @@
 # It however strips some debug info, like --release=fast
 # Option reference:
 # -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
-# -t: "Target." Build release small optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
-%zig_build_small(ta:) %{lua:
+# -a (without option): Build release small optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
+%zig_build_small(a::) %{lua:
    if rpm.isdefined("-a") then
-    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
-   elseif rpm.isdefined("-t") then
-    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
+    rpm.define("_zig_cpu " .. rpm.expand("%{?-a*:%{-a*}}%{?!-a*:%_target_cpu}"))
    end} \
 %global _zig_release_mode small \
 %{shrink: \
@@ -49,4 +45,3 @@
         build \
         %{?_zig_build_options} \
 }
-

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -18,7 +18,11 @@ if rpm.isdefined("-v2") then
     rpm.define("_zig_cpu" .. "x86_64_v4")
     else error("Incompatible architecture for march option.") 
     end
-   end} \
+  elseif rpm.expand("%_target_cpu"):find("^x86_64_v%d$") then
+   local target = rpm.expand("%_target_cpu")
+   rpm.define("_zig_cpu" .. target)
+   end
+end} \
 %{shrink: \
     %zig \
         build \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -5,11 +5,11 @@
 # -a: Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
 # No flag: Fallback to _target_arch
 %zig_build_march(a:) %{lua:
-if rpm.isdefined("-a") then
-  rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
-  else
-  rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
-  end} \
+   if rpm.isdefined("-a") then
+    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
+   else
+    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
+   end} \
 %{shrink: \
     %zig \
         build \
@@ -26,9 +26,9 @@ if rpm.isdefined("-a") then
 %zig_build_fast(ta:) %{lua:
    if rpm.isdefined("-a") then
     rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
-  elseif rpm.isdefined("-t") then
+   elseif rpm.isdefined("-t") then
     rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
-  end} \
+   end} \
 %global _zig_release_mode fast \
 %{shrink: \
     %zig \
@@ -44,9 +44,9 @@ if rpm.isdefined("-a") then
 %zig_build_small(ta:) %{lua:
    if rpm.isdefined("-a") then
     rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
-  elseif rpm.isdefined("-t") then
+   elseif rpm.isdefined("-t") then
     rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
-  end} \
+   end} \
 %global _zig_release_mode small \
 %{shrink: \
     %zig \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -45,7 +45,7 @@ if rpm.isdefined("-2") then
  -- Only succeed with flags on x86_64 architectures.
    if rpm.isdefined("-2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
-    rpm.define("_zig_cpu" .. "x86_64_v2")
+    rpm.define("_zig_cpu " .. "x86_64_v2")
     else error("Incompatible architecture for march option.") 
     end
    elseif rpm.isdefined("-3") then
@@ -61,8 +61,7 @@ if rpm.isdefined("-2") then
   elseif rpm.isdefined("-t") then
     local target = rpm.expand("%_target_cpu")
     rpm.define("_zig_cpu " .. target)
-    end
-   end} \
+  end} \
 %global _zig_release_mode fast \
 %{shrink: \
     %zig \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -25,8 +25,7 @@ if rpm.isdefined("-v2") then
   else
    local target = rpm.expand("%_target_cpu")
    rpm.define("_zig_cpu" .. target)
-   end
-end} \
+  end} \
 %{shrink: \
     %zig \
         build \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -33,7 +33,7 @@
 # --release=small is the recommended way to build some projects, as it builds smaller bins and in some programs has comparable performance
 # It however strips some debug info, like --release=fast
 # Option reference:
-# -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
+# -a (with option): "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
 # -a (without option): Build release small optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
 %zig_build_small(a::) %{lua:
    if rpm.isdefined("-a") then

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -6,7 +6,7 @@
 # -3: Build optimized for x86_64_v3
 # -4: Build optimized for x86_64_v4
 # No flag: Fallback to _target_arch
-%zig_build_march(234:) %{lua:
+%zig_build_march(234) %{lua:
 if rpm.isdefined("-2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu " .. "x86_64_v2")
@@ -41,7 +41,7 @@ if rpm.isdefined("-2") then
 # -3: Build release fast optimized for x86_64_v3
 # -4: Build release fast optimized for x86_64_v4
 # -t:  "Target." Build release fast optimized for _target_arch (fallback option, mainly for ARM architectures)
-%zig_build_fast(234t:) %{lua:
+%zig_build_fast(234t) %{lua:
  -- Only succeed with flags on x86_64 architectures.
    if rpm.isdefined("-2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -2,6 +2,25 @@
 # It however strips some debug info
 # This is best used in projects that have flags to override the debug stripping in fast release mode
 # Example for the above: Ghostty
+%ifarch x86_64_v3
+%zig_build_fast \
+ %global _zig_release_mode fast \
+ %global _zig_cpu x86_64_v3 \
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}
+%elifarch x86_64_v4
+%zig_build_fast \
+ %global _zig_release_mode fast \
+ %global _zig_cpu x86_64_v4 \
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}
+%else
 %zig_build_fast \
  %global _zig_release_mode fast \
 %{shrink: \
@@ -9,10 +28,11 @@
         build \
         %{?_zig_build_options} \
 }
+%endif
 
 # Zig microarch support
 # Generally --release=fast should be used with these
-# But I have made it so by default additional debug info should still be emitted
+# But some packages it may still be desirable to emit extra debug info
 # Note that Zig also supports Zen microarchitectures, however RPM does not
 %zig_build_v3 \
  %global _zig_cpu x86_64_v3 \
@@ -22,25 +42,7 @@
         %{?_zig_build_options} \
 }
 
-%zig_build_v3_fast \
- %global _zig_release_mode fast \
- %global _zig_cpu x86_64_v3 \
-%{shrink: \
-    %zig \
-        build \
-        %{?_zig_build_options} \
-}
-
 %zig_build_v4 \
- %global _zig_cpu x86_64_v4 \
-%{shrink: \
-    %zig \
-        build \
-        %{?_zig_build_options} \
-}
-
-%zig_build_v4_fast \
- %global _zig_release_mode fast \
  %global _zig_cpu x86_64_v4 \
 %{shrink: \
     %zig \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -17,11 +17,13 @@
 # This is best used in projects that have flags to override the debug stripping in fast release mode
 # Example for the above: Ghostty
 # Option reference:
-# -a (with option): "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
-# -a (without option): Build release fast optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
-%zig_build_fast(a::) %{lua:
+# -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
+# -t: "Target." Build release fast optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
+%zig_build_fast(ta:) %{lua:
    if rpm.isdefined("-a") then
-    rpm.define("_zig_cpu " .. rpm.expand("%{?-a*:%{-a*}}%{?!-a*:%_target_cpu}"))
+    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
+   elseif rpm.isdefined("-t") then
+    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
    end} \
 %global _zig_release_mode fast \
 %{shrink: \
@@ -34,10 +36,12 @@
 # It however strips some debug info, like --release=fast
 # Option reference:
 # -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
-# -a (without option): Build release small optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
-%zig_build_small(a::) %{lua:
+# -t: "Target." Build release small optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
+%zig_build_small(ta:) %{lua:
    if rpm.isdefined("-a") then
-    rpm.define("_zig_cpu " .. rpm.expand("%{?-a*:%{-a*}}%{?!-a*:%_target_cpu}"))
+    rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
+   elseif rpm.isdefined("-t") then
+    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
    end} \
 %global _zig_release_mode small \
 %{shrink: \
@@ -45,3 +49,4 @@
         build \
         %{?_zig_build_options} \
 }
+

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -2,9 +2,9 @@
 # Generally --release=fast should be used with these
 # But some packages it may still be desirable to emit extra debug info
 # Note that Zig also supports Zen microarchitectures, however RPM does not
-# -v2: Build optimized for x86_64_v2
-# -v3: Build optimized for x86_64_v3
-# -v4: Build optimized for x86_64_v4
+# -2: Build optimized for x86_64_v2
+# -3: Build optimized for x86_64_v3
+# -4: Build optimized for x86_64_v4
 # No flag: Fallback to _target_arch
 %zig_build_march(234:) %{lua:
 if rpm.isdefined("-2") then
@@ -37,9 +37,9 @@ if rpm.isdefined("-2") then
 # This is best used in projects that have flags to override the debug stripping in fast release mode
 # Example for the above: Ghostty
 # Option reference:
-# -v2: Build release fast optimized for x86_64_v2
-# -v3: Build release fast optimized for x86_64_v3
-# -v4: Build release fast optimized for x86_64_v4
+# -2: Build release fast optimized for x86_64_v2
+# -3: Build release fast optimized for x86_64_v3
+# -4: Build release fast optimized for x86_64_v4
 # -t:  "Target." Build release fast optimized for _target_arch (fallback option, mainly for ARM architectures)
 %zig_build_fast(234t:) \ 
  %global _zig_release_mode fast \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -41,9 +41,7 @@ if rpm.isdefined("-2") then
 # -3: Build release fast optimized for x86_64_v3
 # -4: Build release fast optimized for x86_64_v4
 # -t:  "Target." Build release fast optimized for _target_arch (fallback option, mainly for ARM architectures)
-%zig_build_fast(234t:) \ 
- %global _zig_release_mode fast \
- %{lua:
+%zig_build_fast(234t:) %{lua:
  -- Only succeed with flags on x86_64 architectures.
    if rpm.isdefined("-2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
@@ -65,6 +63,7 @@ if rpm.isdefined("-2") then
     rpm.define("_zig_cpu " .. target)
     end
    end} \
+%global _zig_release_mode fast \
 %{shrink: \
     %zig \
         build \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -22,7 +22,7 @@
 %zig_build_target(cr:) %{lua:
    if opt.c then
     if rpm.expand("%{?1}"):find("%w") then
-     rpm.define("_zig_cpu " .. rpm.expand("%{?1:%{1}}"))
+     rpm.define("_zig_cpu " .. rpm.expand("%{1}"))
     else
      rpm.define("_zig_cpu " .. rpm.expand("%{_target_cpu}"))
     end

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -33,7 +33,7 @@
 # --release=small is the recommended way to build some projects, as it builds smaller bins and in some programs has comparable performance
 # It however strips some debug info, like --release=fast
 # Option reference:
-# -a (with option): "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
+# -a: "Arch." Choose a specific (micro)architecture to build for. Can also be used to enable/disable architecture features
 # -a (without option): Build release small optimized for _target_arch (fallback option, only applicable to arches where RPM and Zig use the same format)
 %zig_build_small(a::) %{lua:
    if rpm.isdefined("-a") then

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -24,7 +24,7 @@
 %zig_build_march \
 %ifarch x86_64_v2
  %global _zig_cpu x86_64_v2 \
-%ifarch x86_64_v3
+%elifarch x86_64_v3
  %global _zig_cpu x86_64_v3 \
 %elifarch x86_64_v4
  %global _zig_cpu x86_64_v4 \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -2,9 +2,23 @@
 # Generally --release=fast should be used with these
 # But some packages it may still be desirable to emit extra debug info
 # Note that Zig also supports Zen microarchitectures, however RPM does not
-%zig_build_march \
-%{expr:0%{lua:if rpm.expand("%_target_cpu"):find("^x86_64_v%d$") then print("1") else error("Unsupported architecture.") end} ? "%_target_cpu" : ""} \
- %global _zig_cpu %{_target_cpu} \
+%zig_build_march(v2v3v4:) %{lua:
+if rpm.isdefined("-v2") then
+    if rpm.expand("%_target_cpu"):find("^x86_64") then 
+    rpm.define("_zig_cpu" .. "x86_64_v2")
+    else error("Incompatible architecture for march option.") 
+    end
+   elseif rpm.isdefined("-v3") then
+    if rpm.expand("%_target_cpu"):find("^x86_64") then 
+    rpm.define("_zig_cpu" .. "x86_64_v3")
+    else error("Incompatible architecture for march option.") 
+    end
+  elseif rpm.isdefined("-v4") then
+    if rpm.expand("%_target_cpu"):find("^x86_64") then 
+    rpm.define("_zig_cpu" .. "x86_64_v4")
+    else error("Incompatible architecture for march option.") 
+    end
+   end} \
 %{shrink: \
     %zig \
         build \
@@ -22,17 +36,17 @@
    if rpm.isdefined("-v2") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu" .. "x86_64_v2")
-    else error("Incompatible build arch and option.") 
+    else error("Incompatible architecture for march option.") 
     end
    elseif rpm.isdefined("-v3") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu" .. "x86_64_v3")
-    else error("Incompatible build arch and option.") 
+    else error("Incompatible architecture for march option.") 
     end
   elseif rpm.isdefined("-v4") then
     if rpm.expand("%_target_cpu"):find("^x86_64") then 
     rpm.define("_zig_cpu" .. "x86_64_v4")
-    else error("Incompatible build arch and option.") 
+    else error("Incompatible architecture for march option.") 
     end
    end} \
 %{shrink: \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -2,48 +2,29 @@
 # It however strips some debug info
 # This is best used in projects that have flags to override the debug stripping in fast release mode
 # Example for the above: Ghostty
+%zig_build_fast \
+ %global _zig_release_mode fast \
 %ifarch x86_64_v3
-%zig_build_fast \
- %global _zig_release_mode fast \
  %global _zig_cpu x86_64_v3 \
-%{shrink: \
-    %zig \
-        build \
-        %{?_zig_build_options} \
-}
 %elifarch x86_64_v4
-%zig_build_fast \
- %global _zig_release_mode fast \
  %global _zig_cpu x86_64_v4 \
-%{shrink: \
-    %zig \
-        build \
-        %{?_zig_build_options} \
-}
-%else
-%zig_build_fast \
- %global _zig_release_mode fast \
-%{shrink: \
-    %zig \
-        build \
-        %{?_zig_build_options} \
-}
 %endif
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}
 
 # Zig microarch support
 # Generally --release=fast should be used with these
 # But some packages it may still be desirable to emit extra debug info
 # Note that Zig also supports Zen microarchitectures, however RPM does not
-%zig_build_v3 \
+%zig_build_march \
+%ifarch x86_64_v3
  %global _zig_cpu x86_64_v3 \
-%{shrink: \
-    %zig \
-        build \
-        %{?_zig_build_options} \
-}
-
-%zig_build_v4 \
+%elifarch x86_64_v4
  %global _zig_cpu x86_64_v4 \
+%endif
 %{shrink: \
     %zig \
         build \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -1,22 +1,3 @@
-# --release=fast is the recommended way to build most projects that rely on performance optimizations
-# It however strips some debug info
-# This is best used in projects that have flags to override the debug stripping in fast release mode
-# Example for the above: Ghostty
-%zig_build_fast \
- %global _zig_release_mode fast \
-%ifarch x86_64_v2
- %global _zig_cpu x86_64_v2 \
-%elifarch x86_64_v3
- %global _zig_cpu x86_64_v3 \
-%elifarch x86_64_v4
- %global _zig_cpu x86_64_v4 \
-%endif
-%{shrink: \
-    %zig \
-        build \
-        %{?_zig_build_options} \
-}
-
 # Zig microarch support
 # Generally --release=fast should be used with these
 # But some packages it may still be desirable to emit extra debug info
@@ -24,6 +5,36 @@
 %zig_build_march \
 %{expr:0%{lua:if rpm.expand("%_target_cpu"):find("^x86_64_v%d$") then print("1") else error("Unsupported architecture.") end} ? "%_target_cpu" : ""} \
  %global _zig_cpu %{_target_cpu} \
+%{shrink: \
+    %zig \
+        build \
+        %{?_zig_build_options} \
+}
+
+# --release=fast is the recommended way to build most projects that rely on performance optimizations
+# It however strips some debug info
+# This is best used in projects that have flags to override the debug stripping in fast release mode
+# Example for the above: Ghostty
+%zig_build_fast(v2v3v4:) \ 
+ %global _zig_release_mode fast \
+ %{lua:
+ -- Only succeed with flags on x86_64 architectures.
+   if rpm.isdefined("-v2") then
+    if rpm.expand("%_target_cpu"):find("^x86_64") then 
+    rpm.define("_zig_cpu" .. "x86_64_v2")
+    else error("Incompatible build arch and option.") 
+    end
+   elseif rpm.isdefined("-v3") then
+    if rpm.expand("%_target_cpu"):find("^x86_64") then 
+    rpm.define("_zig_cpu" .. "x86_64_v3")
+    else error("Incompatible build arch and option.") 
+    end
+  elseif rpm.isdefined("-v4") then
+    if rpm.expand("%_target_cpu"):find("^x86_64") then 
+    rpm.define("_zig_cpu" .. "x86_64_v4")
+    else error("Incompatible build arch and option.") 
+    end
+   end} \
 %{shrink: \
     %zig \
         build \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -21,8 +21,8 @@
 # -r: "Release." Choose the build/release mode Zig will use. Note that "safe" is the default set by the Zig macros so it is never necessary to specify this option.
 %zig_build_target(cr:) %{lua:
    if opt.c then
-    if rpm.expand("%?1"):find("%w") then
-     rpm.define("_zig_cpu " .. rpm.expand("%1"))
+    if rpm.expand("%{?1}"):find("%w") then
+     rpm.define("_zig_cpu " .. rpm.expand("%{?1:%{1}}"))
     else
      rpm.define("_zig_cpu " .. rpm.expand("%{_target_cpu}"))
     end

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -8,8 +8,7 @@
 if rpm.isdefined("-a") then
   rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
   else
-   local target = rpm.expand("%_target_cpu")
-   rpm.define("_zig_cpu " .. target)
+  rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
   end} \
 %{shrink: \
     %zig \
@@ -28,8 +27,7 @@ if rpm.isdefined("-a") then
    if rpm.isdefined("-a") then
     rpm.define("_zig_cpu " .. rpm.expand("%{?-a:%{-a*}}"))
   elseif rpm.isdefined("-t") then
-    local target = rpm.expand("%_target_cpu")
-    rpm.define("_zig_cpu " .. target)
+    rpm.define("_zig_cpu " .. rpm.expand("%_target_cpu"))
   end} \
 %global _zig_release_mode fast \
 %{shrink: \


### PR DESCRIPTION
The Fedora Zig macros aren't the best thing in the world to begin with, but you can see them here: https://src.fedoraproject.org/rpms/zig/blob/rawhide/f/macros.zig

I did this similarly to how the Anda Cargo macros use the existing Cargo macros and only override them as needed, I hope the formatting and everything is correct. LMK what you think? It's my first time making macros aside from trying to make that Zed license one and somehow messing it up.

Obviously the microarch ones are mostly waiting on DNF. However, there are some Zig projects that *only* support v3 and above that can't be built with baseline x86_64 anyway.