### PR TITLE
fix: Don't mangle non-crates.io licenses

### DIFF
--- a/macros.cargo_extra
+++ b/macros.cargo_extra
@@ -55,18 +55,18 @@ EOF\
 %cargo_license_online(naf:)\
 (\
 set -euo pipefail\
-%{shrink:                                                           \
-    %{__cargo} tree                                                 \
-    -Z avoid-dev-deps                                               \
-    --workspace                                                     \
-    --edges no-build,no-dev,no-proc-macro                           \
-    --no-dedupe                                                     \
-    --target all                                                    \
-    %{__cargo_parse_opts %{-n} %{-a} %{-f:-f%{-f*}}}                \
-    --prefix none                                                   \
-    --format "{l}: {p}"                                             \
-    | sed -e "s: ($(pwd)[^)]*)::g" -e "s: / :/:g" -e "s:/: OR :g"   \
-    | sort -u                                                       \
+%{shrink:                                                                                \
+    %{__cargo} tree                                                                      \
+    -Z avoid-dev-deps                                                                    \
+    --workspace                                                                          \
+    --edges no-build,no-dev,no-proc-macro                                                \
+    --no-dedupe                                                                          \
+    --target all                                                                         \
+    %{__cargo_parse_opts %{-n} %{-a} %{-f:-f%{-f*}}}                                     \
+    --prefix none                                                                        \
+    --format "{l}: {p}"                                                                  \
+    | sed -e "s: ($(pwd)[^)]*)::g" -e "s: / :/:g" -e "s:/: OR :g" -e "|/.*:|{s|/| OR |}" \
+    | sort -u                                                                            \
 }\
 )
 

--- a/macros.cargo_extra
+++ b/macros.cargo_extra
@@ -89,7 +89,7 @@ set -euo pipefail\
     %{__cargo_parse_opts %{-n} %{-a} %{-f:-f%{-f*}}}                \
     --prefix none                                                   \
     --format "# {l}"                                                \
-    | sed -e "s: / :/:g" -e "s:/: OR :g"                            \
+    | sed -e "s: / :/:g" -e "s:/: OR :g" -e "|/.*:|{s|/| OR |}"     \
     | sort -u                                                       \
 }\
 )


### PR DESCRIPTION
This is basically what I did for Zed, but what this does is *only* replace the first instance of `/`, before the `[cratename]:` part of the line due to being told to stop before `:`.

Fedora never needed a check like this because they weren't fetching online Crates. When you fetch the license list online you end up with URLs for Crates hosted on sites other than crates.io (such as GitHub) and the command without this check mangles the source URLs.

For an affected package to check ~that doesn't take 40 million years to build~, see Edit.