### PR TITLE
fix(macros.cargo_extra): Switch to embedded Lua to correctly detect OS env

### DIFF
--- a/macros.cargo_extra
+++ b/macros.cargo_extra
@@ -32,9 +32,10 @@ directory = "%{cargo_registry}"\
 \
 EOF\
 %{__rm} -f Cargo.toml.orig \
-%if 0%?fedora > 0\
-%global build_rustflags %build_rustflags %[%{with mold} ? "-C link-arg=-fuse-ld=mold" : ""]\
-%endif\
+%{lua: 
+if rpm.expand("%{fedora}"):find("^%d") then 
+rpm.define("build_rustflags " .. rpm.expand("%build_rustflags %[%{with mold} ? \\"-C link-arg=-fuse-ld=mold\\" : \\"\\"]"))
+end}\
 )
 
 


### PR DESCRIPTION
This does nothing on anything but Fedora (as it only finds output on Fedora) but redefines `%build_rustflags` on Fedora which is what is intended.
![image](https://github.com/user-attachments/assets/a95dc71d-6280-4cb6-8e35-2d9db3bdfd99)
