### PR TITLE
feat(macros.zig_extras): Static option

### DIFF
--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -19,7 +19,8 @@
 # -c (with argument): "CPU." Choose a specific CPU (micro)architecture to build for. Can also be used to enable/disable CPU features (example: AVX2)
 # -c (without argument): Fallback to the target architecture set by RPM (generic option, only applicable to arches where RPM and Zig use the same format)
 # -r: "Release." Choose the build/release mode Zig will use. Note that "safe" is the default set by the Zig macros so it is never necessary to specify this option.
-%zig_build_target(cr:) %{lua:
+# -s: "Static." Use when system integration is not possible or the project has no applicatble build dependencies.
+%zig_build_target(cr:s) %{lua:
    if opt.c then
     if rpm.expand("%{?1}"):find("%w") then
      rpm.define("_zig_cpu " .. rpm.expand("%{1}"))
@@ -29,6 +30,9 @@
    end
    if opt.r then
     rpm.define("_zig_release_mode " .. rpm.expand("%{?-r:%{-r*}}"))
+   end
+   if opt.s then
+    rpm.undefine("_zig_system_integration")
    end} \\\
 %{shrink: \
     %zig \

--- a/macros.zig_extra
+++ b/macros.zig_extra
@@ -19,7 +19,7 @@
 # -c (with argument): "CPU." Choose a specific CPU (micro)architecture to build for. Can also be used to enable/disable CPU features (example: AVX2)
 # -c (without argument): Fallback to the target architecture set by RPM (generic option, only applicable to arches where RPM and Zig use the same format)
 # -r: "Release." Choose the build/release mode Zig will use. Note that "safe" is the default set by the Zig macros so it is never necessary to specify this option.
-# -s: "Static." Use when system integration is not possible or the project has no applicatble build dependencies.
+# -s: "Static." Use when system integration is not possible or the project has no applicatble build dependencies. Dynamic linking for specific packages can still be set via build flags.
 %zig_build_target(cr:s) %{lua:
    if opt.c then
     if rpm.expand("%{?1}"):find("%w") then


### PR DESCRIPTION
This flag is for if system integration is not possible for any reason, including if the project has no applicable build dependencies to fetch.

This happened with falcond as it has no deps to fetch into the cache dir: https://github.com/terrapkg/packages/actions/runs/15755386298/job/44409577252