### PR TITLE
fix(macros.cargo_extra): Correctly set the nightly override for rustup_nightly

### DIFF
--- a/macros.cargo_extra
+++ b/macros.cargo_extra
@@ -131,4 +131,5 @@ set -euo pipefail\
     %global __rustc $HOME/.cargo/bin/rustc      \
     %global __rustdoc $HOME/.cargo/bin/rustdoc  \
     rustup-init --default-toolchain nightly -y  \
-    . "$HOME/.cargo/env"
+    . "$HOME/.cargo/env"                        \
+    rustup override set nightly


### PR DESCRIPTION
Rustup installs the stable toolchain (so it installs the toolchain twice unnecessarily) and can end up using it instead if the override for the working directory is not explicitly set.

Why the hell it does this when the default is nightly I don't understand??