### PR TITLE
feat(macros.cargo_extra) Make rustup_nightly closer to Fedora standards

### DIFF
--- a/macros.cargo_extra
+++ b/macros.cargo_extra
@@ -127,9 +127,9 @@ set -euo pipefail\
 )
 
 %rustup_nightly \
-    %global __cargo /usr/bin/env CARGO_HOME=.cargo RUSTC_BOOTSTRAP=1 RUSTFLAGS='%{build_rustflags}' $HOME/.cargo/bin/cargo \
-    %global __rustc $HOME/.cargo/bin/rustc      \
-    %global __rustdoc $HOME/.cargo/bin/rustdoc  \
-    rustup-init --default-toolchain nightly -y  \
-    . "$HOME/.cargo/env"                        \
+    %global __cargo /usr/bin/env CARGO_HOME=.cargo RUSTFLAGS='%{build_rustflags}' .cargo/bin/cargo \
+    %global __rustc .cargo/bin/rustc                                                               \
+    %global __rustdoc .cargo/bin/rustdoc                                                           \
+    CARGO_HOME=.cargo rustup-init --default-toolchain nightly -y                                   \
+    . ".cargo/env"                                                                                 \
     rustup override set nightly

--- a/macros.cargo_extra
+++ b/macros.cargo_extra
@@ -130,6 +130,6 @@ set -euo pipefail\
     %global __cargo /usr/bin/env CARGO_HOME=.cargo RUSTFLAGS='%{build_rustflags}' .cargo/bin/cargo \
     %global __rustc .cargo/bin/rustc                                                               \
     %global __rustdoc .cargo/bin/rustdoc                                                           \
-    CARGO_HOME=.cargo rustup-init --default-toolchain nightly -y                                   \
+    CARGO_HOME=.cargo RUSTUP_INIT_SKIP_PATH_CHECK=yes rustup-init --default-toolchain nightly      \
     . ".cargo/env"                                                                                 \
     rustup override set nightly


### PR DESCRIPTION
- Unify the `CARGO_HOME`
- `RUSTC_BOOTSTRAP=1` is not needed when using `rustup override set nightly`
- Switch to `RUSTUP_INIT_SKIP_PATH_CHECK` instead of `-y` flag for hopefully less build log spam
- Made backslashes uniform because why not