### PR TITLE
cleanup: Remove unnecessary NPM env var

### DIFF
--- a/macros.nodejs_extra
+++ b/macros.nodejs_extra
@@ -1,6 +1,6 @@
 ## These macros REQUIRE that the macro npm_name be defined or the module be passed to them
 
-%__npm /usr/bin/env NPM_CONFIG_USERCONFIG=%{rpmbuilddir}/.npmrc NPM_CONFIG_GLOBALCONFIG=%{rpmbuilddir}/npmrc NPM_CONFIG_CACHE=%{rpmbuilddir}/.npm NPM_CONFIG_LOGLEVEL=error NPM_CONFIG_FUND=false NPM_CONFIG_INIT_MODULE=%{rpmbuilddir}/.npm-init.js NPM_CONFIG_INIT.MODULE=%{rpmbuilddir}/.npm-init.js NPM_CONFIG_LOGS_DIR=null /usr/bin/npm
+%__npm /usr/bin/env NPM_CONFIG_USERCONFIG=%{rpmbuilddir}/.npmrc NPM_CONFIG_GLOBALCONFIG=%{rpmbuilddir}/npmrc NPM_CONFIG_CACHE=%{rpmbuilddir}/.npm NPM_CONFIG_LOGLEVEL=error NPM_CONFIG_FUND=false NPM_CONFIG_INIT_MODULE=%{rpmbuilddir}/.npm-init.js NPM_CONFIG_INIT.MODULE=%{rpmbuilddir}/.npm-init.js /usr/bin/npm
 
 # For use in prep section
 # -n: "Name." Must be the CANONICAL name of the Node module as hosted on the NPM registry


### PR DESCRIPTION
NPM docs suck so that was *supposed* to disable logging, what it did instead was create a dir called null. Annoying and this should make it fall back to `CACHE_DIR`.