### PR TITLE
fix: Completely avoid touching build_rustflags on EL

### DIFF
--- a/macros.caching
+++ b/macros.caching
@@ -8,8 +8,8 @@
 %global __cc %{__sccache_cc} \
 %global __cxx %{__sccache_cxx}
 
-%cargo_prep_online_sccache \
-%{!?_cargo_home:%global _cargo_home %{rpmbuilddir}%{?buildsubdir:/%{buildsubdir}}/.cargo} \
+%cargo_prep_online_sccache %{expand:
+%{!?_cargo_home:%%global _cargo_home %{rpmbuilddir}%{?buildsubdir:/%{buildsubdir}}/.cargo}} \
 (\
 set -eu \
 %{__mkdir} -p target/rpm\
@@ -49,6 +49,6 @@ directory = "%{cargo_registry}"\
 EOF\
 %{__rm} -f Cargo.toml.orig \
 )\
-%{!?rhel:%global build_rustflags %{terra_rustflags}} \
-%{!?with_rust_nightly:%global __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTC_BOOTSTRAP=1 RUSTC_WRAPPER=%{__sccache} SCCACHE_BUCKET=%{?sccache_bucket} SCCACHE_ENDPOINT=%{?sccache_endpoint} AWS_SECRET_ACCESS_KEY=%{?sccache_secret} AWS_ACCESS_KEY_ID=%{?sccache_accesskey} SCCACHE_S3_USE_SSL=true RUSTFLAGS='%{build_rustflags}' /usr/bin/cargo} \
-%{?with_rust_nightly:%global __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTUP_HOME=%{_rustup_home} RUSTC_WRAPPER=%{__sccache} SCCACHE_BUCKET=%{?sccache_bucket} SCCACHE_ENDPOINT=%{?sccache_endpoint} AWS_SECRET_ACCESS_KEY=%{?sccache_secret} AWS_ACCESS_KEY_ID=%{?sccache_accesskey} SCCACHE_S3_USE_SSL=true RUSTFLAGS='%{build_rustflags}' /usr/bin/cargo}
+%{expand:%{!?rhel:%%global build_rustflags %{terra_rustflags}}
+%{!?with_rust_nightly:%%global __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTC_BOOTSTRAP=1 RUSTC_WRAPPER=%{__sccache} SCCACHE_BUCKET=%{?sccache_bucket} SCCACHE_ENDPOINT=%{?sccache_endpoint} AWS_SECRET_ACCESS_KEY=%{?sccache_secret} AWS_ACCESS_KEY_ID=%{?sccache_accesskey} SCCACHE_S3_USE_SSL=true RUSTFLAGS='%{build_rustflags}' /usr/bin/cargo}
+%{?with_rust_nightly:%%global __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTUP_HOME=%{_rustup_home} RUSTC_WRAPPER=%{__sccache} SCCACHE_BUCKET=%{?sccache_bucket} SCCACHE_ENDPOINT=%{?sccache_endpoint} AWS_SECRET_ACCESS_KEY=%{?sccache_secret} AWS_ACCESS_KEY_ID=%{?sccache_accesskey} SCCACHE_S3_USE_SSL=true RUSTFLAGS='%{build_rustflags}' /usr/bin/cargo}}

--- a/macros.caching
+++ b/macros.caching
@@ -49,6 +49,6 @@ directory = "%{cargo_registry}"\
 EOF\
 %{__rm} -f Cargo.toml.orig \
 )\
-%global build_rustflags %{terra_rustflags} \
+%{!?rhel:%global build_rustflags %{terra_rustflags}} \
 %{!?with_rust_nightly:%global __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTC_BOOTSTRAP=1 RUSTC_WRAPPER=%{__sccache} SCCACHE_BUCKET=%{?sccache_bucket} SCCACHE_ENDPOINT=%{?sccache_endpoint} AWS_SECRET_ACCESS_KEY=%{?sccache_secret} AWS_ACCESS_KEY_ID=%{?sccache_accesskey} SCCACHE_S3_USE_SSL=true RUSTFLAGS='%{build_rustflags}' /usr/bin/cargo} \
 %{?with_rust_nightly:%global __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTUP_HOME=%{_rustup_home} RUSTC_WRAPPER=%{__sccache} SCCACHE_BUCKET=%{?sccache_bucket} SCCACHE_ENDPOINT=%{?sccache_endpoint} AWS_SECRET_ACCESS_KEY=%{?sccache_secret} AWS_ACCESS_KEY_ID=%{?sccache_accesskey} SCCACHE_S3_USE_SSL=true RUSTFLAGS='%{build_rustflags}' /usr/bin/cargo}

--- a/macros.cargo_extra
+++ b/macros.cargo_extra
@@ -1,7 +1,7 @@
 %terra_rustflags %{build_rustflags} %[%{defined fedora} && %{with mold} ? "-Clink-arg=-fuse-ld=mold" : ""]
 
-%cargo_prep_online \
-%{!?_cargo_home:%global _cargo_home %{rpmbuilddir}%{?buildsubdir:/%{buildsubdir}}/.cargo} \
+%cargo_prep_online %{expand:
+%{!?_cargo_home:%%global _cargo_home %{rpmbuilddir}%{?buildsubdir:/%{buildsubdir}}/.cargo}} \
 (\
 set -eu \
 %{__mkdir} -p target/rpm\
@@ -40,8 +40,8 @@ directory = "%{cargo_registry}"\
 EOF\
 %{__rm} -f Cargo.toml.orig \
 )\
-%{!?rhel:%global build_rustflags %{terra_rustflags}} \
-%{!?with_rust_nightly:%global __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTC_BOOTSTRAP=1 RUSTFLAGS='%{build_rustflags}' /usr/bin/cargo}
+%{expand:%{!?rhel:%%global build_rustflags %{terra_rustflags}}
+%{!?with_rust_nightly:%%global __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTC_BOOTSTRAP=1 RUSTFLAGS='%{build_rustflags}' /usr/bin/cargo}}
 
 
 

--- a/macros.cargo_extra
+++ b/macros.cargo_extra
@@ -40,7 +40,7 @@ directory = "%{cargo_registry}"\
 EOF\
 %{__rm} -f Cargo.toml.orig \
 )\
-%global build_rustflags %{terra_rustflags} \
+%{!?rhel:%global build_rustflags %{terra_rustflags}} \
 %{!?with_rust_nightly:%global __cargo /usr/bin/env CARGO_HOME=%{_cargo_home} RUSTC_BOOTSTRAP=1 RUSTFLAGS='%{build_rustflags}' /usr/bin/cargo}
 
 


### PR DESCRIPTION
I  tested the original change in EL10 Mock *and* an Alma VM so I don't know why it still caused recursion in our CI. I am annoyed and tired.